### PR TITLE
Fixed issue with conversion.

### DIFF
--- a/app.py
+++ b/app.py
@@ -11,7 +11,7 @@ def change(amount):
     # divide the amount*100 (the amount in cents) by a coin value
     # record the number of coins that evenly divide and the remainder
     coin = coins.pop()
-    num, rem  = divmod(int(amount*100), coin)
+    num, rem  = divmod(round(amount*100), coin)
     # append the coin type and number of coins that had no remainder
     res.append({num:coin_lookup[coin]})
 


### PR DESCRIPTION
When we put 2.53, the result will be 10 quarters and 2 pennies. But should be 10 quarters and 3 pennies.  The issue is due to 1) amount *100 which will be 252.999 2) int that makes truncation.  So it's better to use round here instead of int.